### PR TITLE
Add CI workflow and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug Report
+about: Create a bug report to help us improve
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+- OS:
+- Kernel version:

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,5 @@
+# Summary
+Describe the main changes of this pull request.
+
+# Testing
+Explain how you tested the changes.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential linux-headers-$(uname -r)
+      - name: Build modules
+        run: make

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ non-production environment before deploying on real hardware.
 
 ### Contributing 🤝
 
-Contributions are the cornerstone of this project's growth and success. Whether it's adding new features, fixing bugs, or improving documentation, your help is greatly appreciated.
+Contributions are the cornerstone of this project's growth and success. Whether it's adding new features, fixing bugs, or improving documentation, your help is greatly appreciated. When opening an issue, please use the templates in `.github/ISSUE_TEMPLATE`. Pull requests should follow the guidelines outlined in `.github/PULL_REQUEST_TEMPLATE`.
 
 ## Support 🤗
 


### PR DESCRIPTION
## Summary
- automate module build on push and PR
- add issue and pull request templates
- document templates in README

## Testing
- `make` *(fails: /lib/modules/6.12.13/build: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6843e8da67948324999b37a78a36d32f