### PR TITLE
Fix license for workqueue module

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -20,5 +20,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-All files in this repository, including the kernel modules in the `src`
-directory, are licensed under the MIT License.
+All files in this repository are licensed under the MIT License except
+`src/kernel_workqueue_module.c`, which is licensed under the GNU General
+Public License (GPL) because it relies on GPL-only kernel symbols.

--- a/README.md
+++ b/README.md
@@ -102,4 +102,6 @@ Encountering challenges or have questions? Open an issue in our issue tracker fo
 
 ## License
 
-All source code and documentation in this repository are released under the [MIT License](LICENSE).
+All source code and documentation in this repository are released under the [MIT License](LICENSE),
+except for `src/kernel_workqueue_module.c` which is licensed under the GNU
+General Public License (GPL) because it uses GPL-only kernel symbols.

--- a/src/kernel_workqueue_module.c
+++ b/src/kernel_workqueue_module.c
@@ -1,7 +1,7 @@
 /*
  * Kernel Workqueue Demo Module
  * Author: Wal33D
- * License: MIT
+ * License: GPL
  *
  * This module illustrates the use of kernel workqueues to manage deferred tasks.
  * It initializes a workqueue and schedules a work item that periodically logs a
@@ -84,6 +84,6 @@ module_init(workqueue_demo_init);
 module_exit(workqueue_demo_exit);
 
 // Set module metadata
-MODULE_LICENSE("MIT");
+MODULE_LICENSE("GPL");
 MODULE_AUTHOR(DRIVER_AUTHOR);
 MODULE_DESCRIPTION(DRIVER_DESC);


### PR DESCRIPTION
## Summary
- switch `kernel_workqueue_module` to GPL license
- note GPL exception in LICENSE and README

## Testing
- `make` *(fails: /lib/modules/6.12.13/build: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6843e9c51d2483248f4a406bf09fb386