### PR TITLE
Improve module test usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,7 @@ clear:
 # Target to view the kernel log buffer
 view:
 	dmesg
+
+# Run module tests (requires root privileges)
+test: all
+	sudo bash tests/module_test.sh

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ To begin your kernel module development journey, you'll need:
     ```
 
 5. **Run Tests**:
-    After building, you can execute the provided test script (requires root privileges) to automatically insert and remove the sample modules:
+    After building, you can run the provided test script using the Makefile. This step requires root privileges and will automatically insert and remove the sample modules:
     ```bash
-    sudo bash tests/module_test.sh
+    make test
     ```
 
 ### Usage Tips

--- a/tests/module_test.sh
+++ b/tests/module_test.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# Ensure the script is executed with root privileges
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root." >&2
+    exit 1
+fi
+
 BUILD_DIR="$(dirname "$0")/../build"
 MODULES=(kernel_birthday_list_module kernel_timer_module kernel_workqueue_module)
 
@@ -11,8 +17,8 @@ for mod in "${MODULES[@]}"; do
         exit 1
     fi
     echo "Inserting $mod_ko"
-    sudo insmod "$mod_ko"
+    insmod "$mod_ko"
     echo "Removing $mod"
-    sudo rmmod "$mod"
+    rmmod "$mod"
     echo
 done


### PR DESCRIPTION
## Summary
- enforce running the test script as root
- add `make test` target and describe it in the README

## Testing
- `make test` *(fails: `/lib/modules/6.12.13/build: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_684414fa91e48324b1fbee8d029bc64a